### PR TITLE
Remove hardcoded GUI and Label names from BASS and VerbCoin templates

### DIFF
--- a/BASS/GlobalScript.asc
+++ b/BASS/GlobalScript.asc
@@ -3,6 +3,11 @@
 // called when the game starts, before the first room is loaded
 function game_start() 
 {
+  // register a GUI to use for the inventory bar
+  TwoClickHandler.RegisterInventoryGui(gInventoryBar);
+
+  // register a Label to use for action text
+  TwoClickHandler.RegisterActionLabel(lblAction);
 }
 
 // called on every game cycle, except when the game is blocked

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -1,9 +1,18 @@
-//----------------------------------------------------------------------------------------------------
-// game_start()
-//----------------------------------------------------------------------------------------------------
-function game_start()
+// label to use for text actions
+Label* action;
+
+// inventory GUI to use
+GUI* interface_inv;
+
+static function TwoClickHandler::RegisterInventoryGui(GUI* inventory_gui)
 {
-  lblAction.Text = "";
+  interface_inv = inventory_gui;
+}
+
+static function TwoClickHandler::RegisterActionLabel(Label* label)
+{
+  action = label;
+  action.Text = "";
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -12,7 +21,10 @@ function game_start()
 function on_mouse_click(MouseButton button)
 {
   // when mouse is clicked, text label is cleared
-  lblAction.Text = "";
+  if (action != null)
+  {
+    action.Text = "";
+  }
   
   // Left Mouse Button on Object/Character/Hotspot/Location
   // when no inventory is selected:
@@ -127,15 +139,19 @@ function on_mouse_click(MouseButton button)
 //----------------------------------------------------------------------------------------------------
 function repeatedly_execute()
 {
-  // Inventory GUI: 
-  if (gInventoryBar.Visible && mouse.y > gInventoryBar.Height)
+  // Inventory GUI:
+  if (interface_inv == null)
   {
-    gInventoryBar.Visible = false;
+    // pass
   }
-  else if (!IsGamePaused() && !gInventoryBar.Visible && mouse.y <= INVENTORY_POPUP_POSITION)
+  else if (interface_inv.Visible && mouse.y > interface_inv.Height)
+  {
+    interface_inv.Visible = false;
+  }
+  else if (!IsGamePaused() && !interface_inv.Visible && mouse.y <= INVENTORY_POPUP_POSITION)
   {
     // make visible when the game is not paused and the cursor is within the popup position
-    gInventoryBar.Visible = true;
+    interface_inv.Visible = true;
   }
   
   // Action Text
@@ -144,21 +160,25 @@ function repeatedly_execute()
   // we display nothing to indicate that an item can not be used on itself
   if (player.ActiveInventory == null)
   {
-    if (!IsGamePaused())
+    if (action != null && !IsGamePaused())
     {
-      lblAction.Text = Game.GetLocationName(mouse.x, mouse.y);
+      action.Text = Game.GetLocationName(mouse.x, mouse.y);
     }
   }
   else
   {
     InventoryItem *i = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
-    if (i != null && i.ID == player.ActiveInventory.ID)
+    if (action == null)
     {
-      lblAction.Text = "";
+      // pass
+    }
+    else if (i != null && i.ID == player.ActiveInventory.ID)
+    {
+      action.Text = "";
     }
     else
     {
-      lblAction.Text = Game.GetLocationName(mouse.x, mouse.y);
+      action.Text = Game.GetLocationName(mouse.x, mouse.y);
     }
   }
 }

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -47,3 +47,8 @@
 
 // change this to the y position the mouse most be at to make the inventory GUI visible
 #define INVENTORY_POPUP_POSITION 15
+
+struct TwoClickHandler {
+  import static function RegisterInventoryGui(GUI* inventory_gui);
+  import static function RegisterActionLabel(Label* label);
+};

--- a/Verb Coin/GlobalScript.asc
+++ b/Verb Coin/GlobalScript.asc
@@ -4,7 +4,8 @@
 function game_start() 
 {
   // setup VerbCoin GUI and buttons
-  VerbCoin.RegisterGui(gVerbCoin);
+  VerbCoin.RegisterInterfaceGui(gVerbCoin);
+  VerbCoin.RegisterInventoryGui(gInventory);
   VerbCoin.RegisterButton(btnLook, eVerbCoinPositionNorth, eModeLookat, "Look at");
   VerbCoin.RegisterButton(btnTalk, eVerbCoinPositionEast, eModeTalkto, "Talk to");
   VerbCoin.RegisterButton(btnInteract, eVerbCoinPositionSouth, eModeInteract, "Use");

--- a/Verb Coin/GlobalScript.asc
+++ b/Verb Coin/GlobalScript.asc
@@ -5,11 +5,14 @@ function game_start()
 {
   // setup VerbCoin GUI and buttons
   VerbCoin.RegisterInterfaceGui(gVerbCoin);
-  VerbCoin.RegisterInventoryGui(gInventory);
   VerbCoin.RegisterButton(btnLook, eVerbCoinPositionNorth, eModeLookat, "Look at");
   VerbCoin.RegisterButton(btnTalk, eVerbCoinPositionEast, eModeTalkto, "Talk to");
   VerbCoin.RegisterButton(btnInteract, eVerbCoinPositionSouth, eModeInteract, "Use");
   VerbCoin.RegisterButton(btnPickup, eVerbCoinPositionWest, eModePickup, "Pick up");
+  
+  // select the inventory GUI and action label
+  VerbCoin.RegisterInventoryGui(gInventory);
+  VerbCoin.RegisterActionLabel(lblAction);
   
   // disable buttons where click events would be unhandled
   //VerbCoin.ButtonAutoDisable(true);

--- a/Verb Coin/VerbCoin.asc
+++ b/Verb Coin/VerbCoin.asc
@@ -1,8 +1,11 @@
 // sprite for the GUI background
 DynamicSprite* sprite;
 
-// GUI to use
+// GUI to use for the verbcoin
 GUI* interface;
+
+// inventory GUI to use
+GUI* interface_inv;
 
 // default settings
 int radius = VERBCOIN_DEFAULT_RADIUS;
@@ -217,7 +220,7 @@ function render()
   interface.BackgroundGraphic = sprite.Graphic;
 }
 
-static function VerbCoin::RegisterGui(GUI* interface_gui)
+static function VerbCoin::RegisterInterfaceGui(GUI* interface_gui)
 {
   interface = interface_gui;
   
@@ -233,6 +236,11 @@ static function VerbCoin::RegisterGui(GUI* interface_gui)
   actionmap = new String[interface.ControlCount];
   enabled = true;
   render();
+}
+
+static function VerbCoin::RegisterInventoryGui(GUI* inventory_gui)
+{
+  interface_inv = inventory_gui;
 }
 
 static function VerbCoin::Enable()
@@ -295,9 +303,9 @@ function on_mouse_click(MouseButton button)
       {
         interface.Visible = false;
       }
-      else if (gInventory.Visible)
+      else if (interface_inv != null && interface_inv.Visible)
       {
-        gInventory.Visible = false;
+        interface_inv.Visible = false;
       }
       else if (Character.GetAtScreenXY(mouse.x, mouse.y) != player)
       {
@@ -325,9 +333,9 @@ function on_mouse_click(MouseButton button)
     {
       interface.Visible = false;
     }
-    else if (gInventory.Visible)
+    else if (interface_inv != null && interface_inv.Visible)
     {
-      gInventory.Visible = false;
+      interface_inv.Visible = false;
     }
     else if (player.ActiveInventory != null)
     {
@@ -351,15 +359,15 @@ function on_mouse_click(MouseButton button)
     {
       player.ActiveInventory = null;
     }
-    else if (gInventory.Visible)
+    else if (interface_inv != null && interface_inv.Visible)
     {
-      gInventory.Visible = false;
+      interface_inv.Visible = false;
     }
-    else
+    else if (interface_inv != null)
     {
       // ...except when there is no nothing to deselect or close,
       // so a right click is also how the inventory is opened
-      gInventory.Visible = true;
+      interface_inv.Visible = true;
     }
   }
   else if (button == eMouseLeftInv)
@@ -376,12 +384,12 @@ function on_mouse_click(MouseButton button)
       // left click to 'combine' items
       item.RunInteraction(eModeUseinv);
     }
-    else
+    else if (interface_inv != null)
     {
       // clicking an item on itself closes the inventory window
       // (this is just a shortcut to avoid moving the cursor, as it means
       // you can just double click an item to also close the window)
-      gInventory.Visible = false;
+      interface_inv.Visible = false;
     }
   }
   else if (button == eMouseRightInv)
@@ -432,7 +440,7 @@ function repeatedly_execute()
         lblAction.Text = context_text;
       }
     }
-    else if (!gInventory.Visible || GetLocationType(mouse.x, mouse.y) == eLocationNothing)
+    else if ((interface_inv != null && !interface_inv.Visible) || GetLocationType(mouse.x, mouse.y) == eLocationNothing)
     {
       // update regular text label
       context_text = Game.GetLocationName(mouse.x, mouse.y);
@@ -441,10 +449,10 @@ function repeatedly_execute()
   }
   else
   {
-    if (gInventory.Visible && GUI.GetAtScreenXY(mouse.x, mouse.y) != gInventory)
+    if (interface_inv != null && interface_inv.Visible && GUI.GetAtScreenXY(mouse.x, mouse.y) != interface_inv)
     {
       // close inventory window once the cursor leaves
-      gInventory.Visible = false;
+      interface_inv.Visible = false;
     }
     
     // update text label for 'combining' items
@@ -464,7 +472,8 @@ function repeatedly_execute()
 function on_event(EventType event, int data) 
 {
   if (event == eEventGUIMouseDown &&
-      data == gInventory.ID &&
+      interface_inv != null &&
+      data == interface_inv.ID &&
       GUIControl.GetAtScreenXY(mouse.x, mouse.y) == invCustom &&
       InventoryItem.GetAtScreenXY(mouse.x, mouse.y) == null)
   {
@@ -474,7 +483,7 @@ function on_event(EventType event, int data)
     }
     else
     {
-      gInventory.Visible = false;
+      interface_inv.Visible = false;
     }
   }
 }

--- a/Verb Coin/VerbCoin.asc
+++ b/Verb Coin/VerbCoin.asc
@@ -7,6 +7,9 @@ GUI* interface;
 // inventory GUI to use
 GUI* interface_inv;
 
+// label to use for text actions
+Label* action_label;
+
 // default settings
 int radius = VERBCOIN_DEFAULT_RADIUS;
 int background_color = VERBCOIN_DEFAULT_BACKGROUND_COLOR;
@@ -243,6 +246,12 @@ static function VerbCoin::RegisterInventoryGui(GUI* inventory_gui)
   interface_inv = inventory_gui;
 }
 
+static function VerbCoin::RegisterActionLabel(Label* label)
+{
+  action_label = label;
+  action_label.Text = "";
+}
+
 static function VerbCoin::Enable()
 {
   enabled = true;
@@ -278,11 +287,6 @@ static function VerbCoin::IsOpen()
 static function VerbCoin::ButtonAutoDisable(bool autodisable)
 {
   button_auto_disable = autodisable;
-}
-
-function game_start()
-{
-  lblAction.Text = "";
 }
 
 function on_mouse_click(MouseButton button)
@@ -431,20 +435,28 @@ function repeatedly_execute()
       // update text label for verb coin actions
       GUIControl* control = GUIControl.GetAtScreenXY(mouse.x, mouse.y);
       
+      if (action_label == null)
+      {
+        // pass
+      }
       if (control != null && control.AsButton != null && control.Enabled)
       {
-        lblAction.Text = String.Format("%s %s", actionmap[control.ID], context_text);
+        action_label.Text = String.Format("%s %s", actionmap[control.ID], context_text);
       }
       else
       {
-        lblAction.Text = context_text;
+        action_label.Text = context_text;
       }
     }
     else if ((interface_inv != null && !interface_inv.Visible) || GetLocationType(mouse.x, mouse.y) == eLocationNothing)
     {
       // update regular text label
       context_text = Game.GetLocationName(mouse.x, mouse.y);
-      lblAction.Text = context_text;
+      
+      if  (action_label != null)
+      {
+        action_label.Text = context_text;
+      }
     }
   }
   else
@@ -464,7 +476,10 @@ function repeatedly_execute()
       location = "...";
     }
     
-    lblAction.Text = String.Format("Use %s with %s", player.ActiveInventory.Name, location);
+    if (action_label != null)
+    {
+      action_label.Text = String.Format("Use %s with %s", player.ActiveInventory.Name, location);
+    }
   }
 }
 

--- a/Verb Coin/VerbCoin.ash
+++ b/Verb Coin/VerbCoin.ash
@@ -22,6 +22,7 @@ struct VerbCoin {
   import static function RegisterButton(GUIControl* control, VerbCoinPosition position, CursorMode mode, String verbtext);
   import static function RegisterInterfaceGui(GUI* interface_gui);
   import static function RegisterInventoryGui(GUI* inventory_gui);
+  import static function RegisterActionLabel(Label* label);
   import static function Enable();
   import static function Disable();
   import static function IsEnabled();

--- a/Verb Coin/VerbCoin.ash
+++ b/Verb Coin/VerbCoin.ash
@@ -20,7 +20,8 @@ struct VerbCoin {
   import static function SetBorderWidth(int width);
   import static function OnClick(GUIControl* control, MouseButton button);
   import static function RegisterButton(GUIControl* control, VerbCoinPosition position, CursorMode mode, String verbtext);
-  import static function RegisterGui(GUI* interface_gui);
+  import static function RegisterInterfaceGui(GUI* interface_gui);
+  import static function RegisterInventoryGui(GUI* inventory_gui);
   import static function Enable();
   import static function Disable();
   import static function IsEnabled();


### PR DESCRIPTION
This removes direct references to GUI and Label names and adds functions to set which ones to use.
e.g. you don't have to have a label named lblAction, or a GUI named gInventory.