### PR TITLE
Further cleanup and add a reversed mouse button mode

### DIFF
--- a/BASS/GlobalScript.asc
+++ b/BASS/GlobalScript.asc
@@ -8,6 +8,9 @@ function game_start()
 
   // register a Label to use for action text
   TwoClickHandler.RegisterActionLabel(lblAction);
+  
+  // optionally reverse the left and right mouse buttons
+  //TwoClickHandler.SetMouseMode(eTwoClickMouseModeClassic);
 }
 
 // called on every game cycle, except when the game is blocked

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -4,6 +4,9 @@ Label* action;
 // inventory GUI to use
 GUI* interface_inv;
 
+// whether trying to be like actual BASS
+bool classic = false;
+
 static function TwoClickHandler::RegisterInventoryGui(GUI* inventory_gui)
 {
   interface_inv = inventory_gui;
@@ -15,6 +18,24 @@ static function TwoClickHandler::RegisterActionLabel(Label* label)
   action.Text = "";
 }
 
+static function TwoClickHandler::SetMouseMode(TwoClickMouseMode mode)
+{
+  classic = mode == eTwoClickMouseModeClassic;
+}
+
+MouseButton check_reversed(MouseButton button)
+{
+  if (classic)
+  {
+    if (button == eMouseLeft) return eMouseRight;
+    if (button == eMouseRight) return eMouseLeft;
+    if (button == eMouseLeftInv) return eMouseRightInv;
+    if (button == eMouseRightInv) return eMouseLeftInv;
+  }
+  
+  return button;
+}
+
 function do_room_action(MouseButton button)
 {
   if (GetLocationType(mouse.x, mouse.y) != eLocationNothing)
@@ -22,7 +43,7 @@ function do_room_action(MouseButton button)
     // clicked on something
     if (player.ActiveInventory == null)
     {
-      if (button == eMouseLeft)
+      if (button == check_reversed(eMouseLeft))
       {
         // left click to interact with target
         Room.ProcessClick(mouse.x, mouse.y, eModeInteract);
@@ -35,7 +56,7 @@ function do_room_action(MouseButton button)
     }
     else
     {
-      if (button == eMouseLeft)
+      if (button == check_reversed(eMouseLeft))
       {
         // left click to use inventory on target
         Room.ProcessClick(mouse.x, mouse.y, eModeUseinv);
@@ -50,7 +71,7 @@ function do_room_action(MouseButton button)
   else
   {
     // click on nothing
-    if (player.ActiveInventory == null && button == eMouseLeft)
+    if (player.ActiveInventory == null)
     {
       // left click to walk
       Room.ProcessClick(mouse.x, mouse.y, eModeWalkto);
@@ -65,7 +86,7 @@ function do_room_action(MouseButton button)
 
 function do_inventory_action(MouseButton button, InventoryItem* item)
 { 
-  if (button == eMouseLeftInv)
+  if (button == check_reversed(eMouseLeftInv))
   {  
     if (player.ActiveInventory == null)
     {
@@ -84,6 +105,11 @@ function do_inventory_action(MouseButton button, InventoryItem* item)
     {
       // left click to use active inventory on another item
       item.RunInteraction(eModeUseinv);
+    }
+    else
+    {
+      // left click item on itself to deselect it
+      player.ActiveInventory = null;
     }
   }
   else

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -15,6 +15,84 @@ static function TwoClickHandler::RegisterActionLabel(Label* label)
   action.Text = "";
 }
 
+function do_room_action(MouseButton button)
+{
+  if (GetLocationType(mouse.x, mouse.y) != eLocationNothing)
+  {
+    // clicked on something
+    if (player.ActiveInventory == null)
+    {
+      if (button == eMouseLeft)
+      {
+        // left click to interact with target
+        Room.ProcessClick(mouse.x, mouse.y, eModeInteract);
+      }
+      else
+      {
+        // right click to look at target
+        Room.ProcessClick(mouse.x, mouse.y, eModeLookat);
+      }
+    }
+    else
+    {
+      if (button == eMouseLeft)
+      {
+        // left click to use inventory on target
+        Room.ProcessClick(mouse.x, mouse.y, eModeUseinv);
+      }
+      else
+      {
+        // right click to deselect inventory item
+        player.ActiveInventory = null;
+      }
+    }
+  }
+  else
+  {
+    // click on nothing
+    if (player.ActiveInventory == null && button == eMouseLeft)
+    {
+      // left click to walk
+      Room.ProcessClick(mouse.x, mouse.y, eModeWalkto);
+    }
+    else
+    {
+      // right click to deselect inventory item
+      player.ActiveInventory = null;
+    }
+  }
+}
+
+function do_inventory_action(MouseButton button, InventoryItem* item)
+{ 
+  if (button == eMouseLeftInv)
+  {  
+    if (player.ActiveInventory == null)
+    {
+      if (item.GetProperty("InstantUse") == true)
+      {
+        // left click to instant use (if property is set)
+        item.RunInteraction(eModeInteract);
+      }
+      else
+      {
+        // left click to set active inventory item
+        player.ActiveInventory = item;
+      }
+    }
+    else if (item.ID != player.ActiveInventory.ID)
+    {
+      // left click to use active inventory on another item
+      item.RunInteraction(eModeUseinv);
+    }
+  }
+  else
+  {
+    // right click to look at inventory item
+    item.RunInteraction(eModeLookat);
+  }
+}
+
 //----------------------------------------------------------------------------------------------------
 // on_mouse_click()
 //----------------------------------------------------------------------------------------------------
@@ -25,113 +103,15 @@ function on_mouse_click(MouseButton button)
   {
     action.Text = "";
   }
-  
-  // Left Mouse Button on Object/Character/Hotspot/Location
-  // when no inventory is selected:
-  // - INTERACT with target
-  // - walk to location
-  // else
-  // - USE inventory on target
-  if (!IsGamePaused() && button == eMouseLeft)
-  {
-    if (GetLocationType(mouse.x, mouse.y) != eLocationNothing)
-    {
-      if (player.ActiveInventory == null)
-      {
-        Room.ProcessClick(mouse.x, mouse.y, eModeInteract);
-      }
-      else
-      {
-        Room.ProcessClick(mouse.x, mouse.y, eModeUseinv);
-      }
-    }
-    else
-    {
-      if (player.ActiveInventory == null)
-      {
-        Room.ProcessClick(mouse.x, mouse.y, eModeWalkto);
-      }
-      else
-      {
-        player.ActiveInventory = null;
-      }
-    }       
-  }
 
-  // Right Mouse Button on Object/Character/Hotspot/Location
-  // when no inventory is selected:
-  // - EXAMINE target
-  // else
-  // - DESELECT inventory
-  else if (!IsGamePaused() && button == eMouseRight)
+  if (!IsGamePaused() && (button == eMouseLeft || button == eMouseRight))
   {
-    if (player.ActiveInventory != null)
-    {
-      player.ActiveInventory = null;
-    }
-    else if (GetLocationType(mouse.x, mouse.y) != eLocationNothing)
-    {
-      Room.ProcessClick(mouse.x, mouse.y, eModeLookat);
-    }
+    do_room_action(button);       
   }
-  
-  // Left Mouse Button on Inventory Item
-  // when no inventory is selected:
-  // - INTERACT with target 
-  // - SELECT target
-  // else
-  // - USE inventory on target
-  else if (button == eMouseLeftInv)
+  else if (button == eMouseLeftInv || button == eMouseRightInv)
   {
-    InventoryItem *i = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
-    if (i != null)
-    {
-      if (i.GetProperty("InstantUse") == true)
-      {
-        if (player.ActiveInventory == null)
-        {
-          i.RunInteraction(eModeInteract);
-        }
-        else
-        {
-          i.RunInteraction(eModeUseinv);
-        }
-      }
-      else
-      {
-        if (player.ActiveInventory == null)
-        {
-          player.ActiveInventory = i;
-        }
-        else if (i.ID != player.ActiveInventory.ID)
-        {
-          i.RunInteraction(eModeUseinv);
-        }
-      }
-    }
-  }
-  
-  // Right Mouse Button on Inventory Item
-  // when no inventory is selected:
-  // - EXAMINE target
-  // else
-  // - DESELECT INVENTORY
-  else if (button == eMouseRightInv)
-  {
-    if (player.ActiveInventory != null)
-    {
-      player.ActiveInventory = null;
-    }
-    else
-    {
-      InventoryItem *i = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
-      if (i != null)
-      {
-        i.RunInteraction(eModeLookat);
-      }
-    }
-  }
-  
+    do_inventory_action(button, InventoryItem.GetAtScreenXY(mouse.x, mouse.y));
+  }  
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -167,18 +147,39 @@ function repeatedly_execute()
   }
   else
   {
-    InventoryItem *i = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
+    InventoryItem *item = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
     if (action == null)
     {
       // pass
     }
-    else if (i != null && i.ID == player.ActiveInventory.ID)
+    else if (item != null && item.ID == player.ActiveInventory.ID)
     {
       action.Text = "";
     }
     else
     {
       action.Text = Game.GetLocationName(mouse.x, mouse.y);
+    }
+  }
+}
+
+// handle clicks in the inventory area that are not on an inventory item
+function on_event(EventType event, int data) 
+{
+  if (event == eEventGUIMouseDown &&
+    interface_inv != null &&
+    data == interface_inv.ID &&
+    InventoryItem.GetAtScreenXY(mouse.x, mouse.y) == null)
+  {
+    GUIControl* control = GUIControl.GetAtScreenXY(mouse.x, mouse.y);
+    
+    if (control == null || control.AsInvWindow == null)
+    {
+      // pass
+    }
+    else if (player.ActiveInventory != null)
+    {
+      player.ActiveInventory = null;
     }
   }
 }

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -48,7 +48,13 @@
 // change this to the y position the mouse most be at to make the inventory GUI visible
 #define INVENTORY_POPUP_POSITION 15
 
+enum TwoClickMouseMode {
+	eTwoClickMouseModeNormal, 
+	eTwoClickMouseModeClassic
+};
+
 struct TwoClickHandler {
   import static function RegisterInventoryGui(GUI* inventory_gui);
   import static function RegisterActionLabel(Label* label);
+  import static function SetMouseMode(TwoClickMouseMode mode);
 };

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -1,7 +1,7 @@
 // Script header for the "Lightweight BASS Template"
 //
 //
-// Version: 2.1
+// Version: 2.2
 //
 //
 // Author(s): 


### PR DESCRIPTION
- adds reversed mouse button mode (fixes #11)
 `TwoClickHandler.SetMouseMode(eTwoClickMouseModeClassic)`
- walk when right clicking on nothing with no active inventory (was previously unhandled)
- use inventory on itself to deselect it (was previously unhandled)
- handle inventory window clicks to deselect inventory
- removes code that would never be reached (null InventoryItem actions when the mouse button event was eMouseLeftInv or eMouseRightInv, the item will never be null)