### PR TITLE
Fixes for modified GUI visibility and leaving a room

### DIFF
--- a/Verb Coin/VerbCoin.asc
+++ b/Verb Coin/VerbCoin.asc
@@ -131,9 +131,12 @@ static function VerbCoin::SetBorderWidth(int width)
 
 static function VerbCoin::OnClick(GUIControl* control, MouseButton button)
 {
-  interface.Visible = false;
+  if (interface != null)
+  {
+    interface.Visible = false;
+  }
   
-  if (button == eMouseLeft || button == eMouseRight)
+  if (modemap != null && (button == eMouseLeft || button == eMouseRight))
   {
     Room.ProcessClick(context_x, context_y, modemap[control.ID]);
   }
@@ -271,17 +274,23 @@ static function VerbCoin::IsEnabled()
 
 static function VerbCoin::Open()
 {
-  interface.Visible = true;
+  if (interface != null)
+  {
+    interface.Visible = true;
+  }
 }
 
 static function VerbCoin::Close()
 {
-  interface.Visible = false;
+  if (interface != null)
+  {
+    interface.Visible = false;
+  }
 }
 
 static function VerbCoin::IsOpen()
 {
-  return interface.Visible;
+  return interface != null && interface.Visible;
 }
 
 static function VerbCoin::ButtonAutoDisable(bool autodisable)
@@ -439,11 +448,11 @@ function repeatedly_execute()
       {
         // pass
       }
-      if (control != null && control.AsButton != null && control.Enabled)
+      else if (control != null && control.AsButton != null && control.Enabled && context_text != null)
       {
         action_label.Text = String.Format("%s %s", actionmap[control.ID], context_text);
       }
-      else
+      else if (context_text != null)
       {
         action_label.Text = context_text;
       }
@@ -453,7 +462,7 @@ function repeatedly_execute()
       // update regular text label
       context_text = Game.GetLocationName(mouse.x, mouse.y);
       
-      if  (action_label != null)
+      if (action_label != null)
       {
         action_label.Text = context_text;
       }
@@ -483,14 +492,19 @@ function repeatedly_execute()
   }
 }
 
-// handle clicks in the inventory area that are not on an inventory item
 function on_event(EventType event, int data) 
 {
-  if (event == eEventGUIMouseDown &&
+  if (event == eEventLeaveRoom && interface != null) 
+  {
+    // hide interface when changing rooms
+    interface.Visible = false;
+  }
+  else if (event == eEventGUIMouseDown &&
       interface_inv != null &&
       data == interface_inv.ID &&
       InventoryItem.GetAtScreenXY(mouse.x, mouse.y) == null)
   {
+    // handle clicks in the inventory area that are not on an inventory item
     GUIControl* control = GUIControl.GetAtScreenXY(mouse.x, mouse.y);
     
     if (control == null || control.AsInvWindow == null)


### PR DESCRIPTION
- Closes the interface when leaving the room (previously, if GUI visibility is not blocking, you could carry the open interface to the next room)
- Fix crashes where GUI visibility opens the interface, but the module hadn't been initialised. It won't work, but better to do nothing rather than crash.