### PR TITLE
Fix potential crash when clicking inventory items

### DIFF
--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -136,7 +136,9 @@ function on_mouse_click(MouseButton button)
   }
   else if (button == eMouseLeftInv || button == eMouseRightInv)
   {
-    do_inventory_action(button, InventoryItem.GetAtScreenXY(mouse.x, mouse.y));
+    // InventoryItem.GetAtScreenXY could return null here
+    // so using game.inv_activated instead is a safer option
+    do_inventory_action(button, inventory[game.inv_activated]);
   }  
 }
 

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -1,7 +1,7 @@
 // Script header for the "Lightweight BASS Template"
 //
 //
-// Version: 2.2
+// Version: 2.3
 //
 //
 // Author(s): 

--- a/Verb Coin/VerbCoin.asc
+++ b/Verb Coin/VerbCoin.asc
@@ -385,7 +385,9 @@ function on_mouse_click(MouseButton button)
   }
   else if (button == eMouseLeftInv)
   {
-    InventoryItem* item = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
+    // InventoryItem.GetAtScreenXY could return null here
+    // so using game.inv_activated instead is a safer option
+    InventoryItem* item = inventory[game.inv_activated];
     
     if (player.ActiveInventory == null)
     {
@@ -407,7 +409,9 @@ function on_mouse_click(MouseButton button)
   }
   else if (button == eMouseRightInv)
   {
-    InventoryItem* item = InventoryItem.GetAtScreenXY(mouse.x, mouse.y);
+    // InventoryItem.GetAtScreenXY could return null here
+    // so using game.inv_activated instead is a safer option
+    InventoryItem* item = inventory[game.inv_activated];
     
     if (player.ActiveInventory == null && item != null)
     {


### PR DESCRIPTION
eMouseLeftInv and eMouseRightInv events should only fire when clicking on inventory items, but an immediate check with `InventoryItem.GetAtScreenXY` is not reliable enough to return the clicked item every time.

Resolving the item using `game.inv_activated` instead stops a potential crash.