### PR TITLE
Switch to using attributes

### DIFF
--- a/BASS/GlobalScript.asc
+++ b/BASS/GlobalScript.asc
@@ -14,7 +14,7 @@ function game_start()
   //TwoClickHandler.PopupDistance = 50;
 
   // optionally reverse the left and right mouse buttons
-  //TwoClickHandler.ReversedClicks = eTwoClickMouseModeClassic;
+  //TwoClickHandler.ReversedClicks = true;
 }
 
 // called on every game cycle, except when the game is blocked

--- a/BASS/GlobalScript.asc
+++ b/BASS/GlobalScript.asc
@@ -4,13 +4,17 @@
 function game_start() 
 {
   // register a GUI to use for the inventory bar
-  TwoClickHandler.RegisterInventoryGui(gInventoryBar);
+  TwoClickHandler.InventoryGUI = gInventoryBar;
 
   // register a Label to use for action text
-  TwoClickHandler.RegisterActionLabel(lblAction);
-  
+  TwoClickHandler.ActionLabel = lblAction;
+
+  // optionally set the popup distance for the inventory bar
+  //TwoClickHandler.PopupProportional = 0.5;
+  //TwoClickHandler.PopupDistance = 50;
+
   // optionally reverse the left and right mouse buttons
-  //TwoClickHandler.SetMouseMode(eTwoClickMouseModeClassic);
+  //TwoClickHandler.ReversedClicks = eTwoClickMouseModeClassic;
 }
 
 // called on every game cycle, except when the game is blocked

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -69,7 +69,7 @@ float get_PopupProportional(this TwoClickHandler*)
   return popup_proportional;
 }
 
-bool check_popup_distance(int y)
+bool check_show_distance(int y)
 {
   if (y < popup_distance)
   {
@@ -83,6 +83,18 @@ bool check_popup_distance(int y)
   }
 
   return false;
+}
+
+bool check_hide_distance(int y)
+{
+  if (interface_inv == null)
+  {
+    return y > popup_distance;
+  }
+  
+  return y > popup_distance &&
+    y > interface_inv.Height &&
+    y > FloatToInt(IntToFloat(interface_inv.Height) * popup_proportional, eRoundNearest);
 }
 
 MouseButton check_reversed(MouseButton button)
@@ -214,11 +226,11 @@ function repeatedly_execute()
   {
     // pass
   }
-  else if (interface_inv.Visible && mouse.y > interface_inv.Height)
+  else if (interface_inv.Visible && check_hide_distance(mouse.y))
   {
     interface_inv.Visible = false;
   }
-  else if (!IsGamePaused() && !interface_inv.Visible && check_popup_distance(mouse.y))
+  else if (!IsGamePaused() && !interface_inv.Visible && check_show_distance(mouse.y))
   {
     // make visible when the game is not paused and the cursor is within the popup position
     interface_inv.Visible = true;

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -1,26 +1,88 @@
 // label to use for text actions
 Label* action;
 
-// inventory GUI to use
-GUI* interface_inv;
-
-// whether trying to be like actual BASS
-bool classic = false;
-
-static function TwoClickHandler::RegisterInventoryGui(GUI* inventory_gui)
-{
-  interface_inv = inventory_gui;
-}
-
-static function TwoClickHandler::RegisterActionLabel(Label* label)
+void set_ActionLabel(this TwoClickHandler*,  Label* label)
 {
   action = label;
   action.Text = "";
 }
 
-static function TwoClickHandler::SetMouseMode(TwoClickMouseMode mode)
+Label* get_ActionLabel(this TwoClickHandler*)
+{
+  return action;
+}
+
+// GUI to use as inventory
+GUI* interface_inv;
+
+void set_InventoryGUI(this TwoClickHandler*,  GUI* invGui)
+{
+  interface_inv = invGui;
+}
+
+GUI* get_InventoryGUI(this TwoClickHandler*)
+{
+  return interface_inv;
+}
+
+// reversed control mode (left click to look)
+bool classic = false;
+
+void set_ReversedClicks(this TwoClickHandler*, TwoClickMouseMode mode)
 {
   classic = mode == eTwoClickMouseModeClassic;
+}
+
+TwoClickMouseMode get_ReversedClicks(this TwoClickHandler*)
+{
+  if (classic)
+  {
+    return eTwoClickMouseModeClassic;
+  }
+  
+  return eTwoClickMouseModeNormal;
+}
+
+// popup distance from screen edge
+int popup_distance = 0;
+
+void set_PopupDistance(this TwoClickHandler*, int distance)
+{
+  popup_distance = distance;
+}
+
+int get_PopupDistance(this TwoClickHandler*)
+{
+  return popup_distance;
+}
+
+// popup distance proportional to GUI height
+float popup_proportional = 0.75;
+
+void set_PopupProportional(this TwoClickHandler*, float height)
+{
+  popup_proportional = height;
+}
+
+float get_PopupProportional(this TwoClickHandler*)
+{
+  return popup_proportional;
+}
+
+bool check_popup_distance(int y)
+{
+  if (y < popup_distance)
+  {
+    return true;
+  }
+  
+  if (interface_inv != null &&
+    y < FloatToInt(IntToFloat(interface_inv.Height) * popup_proportional, eRoundNearest))
+  {
+      return true;
+  }
+
+  return false;
 }
 
 MouseButton check_reversed(MouseButton button)
@@ -156,7 +218,7 @@ function repeatedly_execute()
   {
     interface_inv.Visible = false;
   }
-  else if (!IsGamePaused() && !interface_inv.Visible && mouse.y <= INVENTORY_POPUP_POSITION)
+  else if (!IsGamePaused() && !interface_inv.Visible && check_popup_distance(mouse.y))
   {
     // make visible when the game is not paused and the cursor is within the popup position
     interface_inv.Visible = true;

--- a/BASS/TwoClickHandler.asc
+++ b/BASS/TwoClickHandler.asc
@@ -28,19 +28,14 @@ GUI* get_InventoryGUI(this TwoClickHandler*)
 // reversed control mode (left click to look)
 bool classic = false;
 
-void set_ReversedClicks(this TwoClickHandler*, TwoClickMouseMode mode)
+void set_ReversedClicks(this TwoClickHandler*, bool reversed)
 {
-  classic = mode == eTwoClickMouseModeClassic;
+  classic = reversed;
 }
 
-TwoClickMouseMode get_ReversedClicks(this TwoClickHandler*)
+bool get_ReversedClicks(this TwoClickHandler*)
 {
-  if (classic)
-  {
-    return eTwoClickMouseModeClassic;
-  }
-  
-  return eTwoClickMouseModeNormal;
+  return classic;
 }
 
 // popup distance from screen edge

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -45,11 +45,6 @@
 // *It's been tested a lot though, and we have established it will not turn your computer into a steaming pile of 
 // pumpkins.
 
-enum TwoClickMouseMode {
-  eTwoClickMouseModeNormal, 
-  eTwoClickMouseModeClassic
-};
-
 struct TwoClickHandler {
   import static attribute Label* ActionLabel;
   import static attribute GUI* InventoryGUI;

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -45,16 +45,15 @@
 // *It's been tested a lot though, and we have established it will not turn your computer into a steaming pile of 
 // pumpkins.
 
-// change this to the y position the mouse most be at to make the inventory GUI visible
-#define INVENTORY_POPUP_POSITION 15
-
 enum TwoClickMouseMode {
 	eTwoClickMouseModeNormal, 
 	eTwoClickMouseModeClassic
 };
 
 struct TwoClickHandler {
-  import static function RegisterInventoryGui(GUI* inventory_gui);
-  import static function RegisterActionLabel(Label* label);
-  import static function SetMouseMode(TwoClickMouseMode mode);
+  import static attribute Label* ActionLabel;
+  import static attribute GUI* InventoryGUI;
+  import static attribute bool ReversedClicks;
+  import static attribute float PopupProportional;
+  import static attribute int PopupDistance;
 };

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -1,7 +1,7 @@
 // Script header for the "Lightweight BASS Template"
 //
 //
-// Version: 2.3
+// Version: 2.4
 //
 //
 // Author(s): 

--- a/BASS/TwoClickHandler.ash
+++ b/BASS/TwoClickHandler.ash
@@ -46,8 +46,8 @@
 // pumpkins.
 
 enum TwoClickMouseMode {
-	eTwoClickMouseModeNormal, 
-	eTwoClickMouseModeClassic
+  eTwoClickMouseModeNormal, 
+  eTwoClickMouseModeClassic
 };
 
 struct TwoClickHandler {

--- a/Sierra-style/Game.agf
+++ b/Sierra-style/Game.agf
@@ -3253,7 +3253,7 @@ See KeyboardMovement.txt for details.
 See KeyboardMovement.txt for details.
 </Description>
                 <Author>Rui "Brisby" Pires / strazer / AGS Team</Author>
-                <Version>1.03</Version>
+                <Version>1.04</Version>
                 <Key>160503183</Key>
                 <IsHeader>False</IsHeader>
               </Script>

--- a/Sierra-style/GlobalScript.asc
+++ b/Sierra-style/GlobalScript.asc
@@ -84,7 +84,13 @@ function game_start()
   initialize_control_panel();
   
   // set KeyboardMovement movement mode
-  KeyboardMovement.SetMode(eKeyboardMovementModeTapping);
+  KeyboardMovement.Mode = eKeyboardMovementModeTapping;
+  
+  // set KeyboardMovement keys
+  //KeyboardMovement.KeyUp = eKeyW;
+  //KeyboardMovement.KeyDown = eKeyS;
+  //KeyboardMovement.KeyLeft = eKeyA;
+  //KeyboardMovement.KeyRight = eKeyD;
 }
 
 // called on every game cycle, except when the game is blocked

--- a/Sierra-style/KeyboardMovement.asc
+++ b/Sierra-style/KeyboardMovement.asc
@@ -1,10 +1,6 @@
 // Main script for module 'KeyboardMovement'
 
-// stores current keyboard control mode (disabled by default)
-KeyboardMovementMode mode = eKeyboardMovementModeNone;
-
-// define a keymap and direction vectors
-KeyboardMovementKeymap keymap;
+// define direction vectors
 KeyboardMovementDirection direction;
 
 // stores current walking direction of player character and a multiplier
@@ -15,24 +11,60 @@ int distance;
 int lastkey = 0;
 bool keydown = false;
 
-static function KeyboardMovement::SetMode(KeyboardMovementMode newmode) {
+// stores current keyboard control mode (disabled by default)
+KeyboardMovementMode mode = eKeyboardMovementModeNone;
+
+void set_Mode(this KeyboardMovement*, KeyboardMovementMode newmode)
+{
   mode = newmode;
 }
 
-static function KeyboardMovement::SetKeyUp(eKeyCode up) {
+KeyboardMovementMode get_Mode(this KeyboardMovement*)
+{
+  return mode;
+}
+
+// store keymap
+KeyboardMovementKeymap keymap;
+
+// up
+void set_KeyUp(this KeyboardMovement*, eKeyCode up)
+{
   keymap.KeyUp = up;
 }
+eKeyCode get_KeyUp(this KeyboardMovement*)
+{
+  return keymap.KeyUp;
+}
 
-static function KeyboardMovement::SetKeyDown(eKeyCode down) {
+// down
+void set_KeyDown(this KeyboardMovement*, eKeyCode down)
+{
   keymap.KeyDown = down;
 }
-
-static function KeyboardMovement::SetKeyLeft(eKeyCode left) {
-  keymap.KeyLeft = left;
+eKeyCode get_KeyDown(this KeyboardMovement*)
+{
+  return keymap.KeyDown;
 }
 
-static function KeyboardMovement::SetKeyRight(eKeyCode right) {
+// left
+void set_KeyLeft(this KeyboardMovement*, eKeyCode left)
+{
+  keymap.KeyLeft = left;
+}
+eKeyCode get_KeyLeft(this KeyboardMovement*)
+{
+  return keymap.KeyLeft;
+}
+
+// right
+void set_KeyRight(this KeyboardMovement*, eKeyCode right)
+{
   keymap.KeyRight = right;
+}
+eKeyCode get_KeyRight(this KeyboardMovement*)
+{
+  return keymap.KeyRight;
 }
 
 Vector* make_vector(int x, int y)

--- a/Sierra-style/KeyboardMovement.ash
+++ b/Sierra-style/KeyboardMovement.ash
@@ -28,9 +28,9 @@ struct KeyboardMovementDirection {
 };
 
 struct KeyboardMovement {
-  import static function SetMode(KeyboardMovementMode newmode);
-  import static function SetKeyUp(eKeyCode up);
-  import static function SetKeyDown(eKeyCode down);
-  import static function SetKeyLeft(eKeyCode left);
-  import static function SetKeyRight(eKeyCode right);
+  import static attribute KeyboardMovementMode Mode;
+  import static attribute eKeyCode KeyUp;
+  import static attribute eKeyCode KeyDown;
+  import static attribute eKeyCode KeyLeft;
+  import static attribute eKeyCode KeyRight;
 };

--- a/Sierra-style/KeyboardMovement.ash
+++ b/Sierra-style/KeyboardMovement.ash
@@ -1,6 +1,6 @@
 // Script header for module 'KeyboardMovement'
 
-#define KeyboardMovement_VERSION 103
+#define KeyboardMovement_VERSION 104
 
 enum KeyboardMovementMode {
 	eKeyboardMovementModeNone, 

--- a/Verb Coin/GlobalScript.asc
+++ b/Verb Coin/GlobalScript.asc
@@ -4,18 +4,18 @@
 function game_start() 
 {
   // setup VerbCoin GUI and buttons
-  VerbCoin.RegisterInterfaceGui(gVerbCoin);
+  VerbCoin.InterfaceGui = gVerbCoin;
   VerbCoin.RegisterButton(btnLook, eVerbCoinPositionNorth, eModeLookat, "Look at");
   VerbCoin.RegisterButton(btnTalk, eVerbCoinPositionEast, eModeTalkto, "Talk to");
   VerbCoin.RegisterButton(btnInteract, eVerbCoinPositionSouth, eModeInteract, "Use");
   VerbCoin.RegisterButton(btnPickup, eVerbCoinPositionWest, eModePickup, "Pick up");
   
   // select the inventory GUI and action label
-  VerbCoin.RegisterInventoryGui(gInventory);
-  VerbCoin.RegisterActionLabel(lblAction);
+  VerbCoin.InventoryGui = gInventory;
+  VerbCoin.ActionLabel = lblAction;
   
   // disable buttons where click events would be unhandled
-  //VerbCoin.ButtonAutoDisable(true);
+  //VerbCoin.ButtonAutoDisable = true;
 }
 
 // called on every game cycle, except when the game is blocked

--- a/Verb Coin/VerbCoin.asc
+++ b/Verb Coin/VerbCoin.asc
@@ -71,7 +71,7 @@ function set_buttons_enabled(bool state)
   }
 }
 
-static function VerbCoin::SetRadius(int newradius)
+void set_Radius(this VerbCoin*, int newradius)
 { 
   if (newradius < 1)
   {
@@ -85,7 +85,12 @@ static function VerbCoin::SetRadius(int newradius)
   }
 }
 
-static function VerbCoin::SetBackgroundTransparency(int transparency)
+int get_Radius(this VerbCoin*)
+{
+  return radius;
+}
+
+void set_BackgroundTransparency(this VerbCoin*, int transparency)
 {
   transparency = Maths.Clamp(transparency, 0, 100);
   
@@ -96,7 +101,12 @@ static function VerbCoin::SetBackgroundTransparency(int transparency)
   }
 }
 
-static function VerbCoin::SetBackgroundColor(int color)
+int get_BackgroundTransparency(this VerbCoin*)
+{
+  return background_transparency;
+}
+
+void set_BackgroundColor(this VerbCoin*, int color)
 {
   color = Maths.Clamp(color, 0, 65535);
   
@@ -107,7 +117,12 @@ static function VerbCoin::SetBackgroundColor(int color)
   }
 }
 
-static function VerbCoin::SetBorderColor(int color)
+int get_BackgroundColor(this VerbCoin*)
+{
+  return background_color;
+}
+
+void set_BorderColor(this VerbCoin*, int color)
 {
   color = Maths.Clamp(color, 0, 65535);
   
@@ -118,7 +133,12 @@ static function VerbCoin::SetBorderColor(int color)
   }
 }
 
-static function VerbCoin::SetBorderWidth(int width)
+int get_BorderColor(this VerbCoin*)
+{
+  return border_color;
+}
+
+void set_BorderWidth(this VerbCoin*, int width)
 {
   width = Maths.Clamp(width, 0, radius);
   
@@ -127,6 +147,11 @@ static function VerbCoin::SetBorderWidth(int width)
     border_width = width;
     redraw = true;
   }
+}
+
+int get_BorderWidth(this VerbCoin*)
+{
+  return border_width;
 }
 
 static function VerbCoin::OnClick(GUIControl* control, MouseButton button)
@@ -226,7 +251,7 @@ function render()
   interface.BackgroundGraphic = sprite.Graphic;
 }
 
-static function VerbCoin::RegisterInterfaceGui(GUI* interface_gui)
+void set_InterfaceGui(this VerbCoin*, GUI* interface_gui)
 {
   interface = interface_gui;
   
@@ -244,15 +269,30 @@ static function VerbCoin::RegisterInterfaceGui(GUI* interface_gui)
   render();
 }
 
-static function VerbCoin::RegisterInventoryGui(GUI* inventory_gui)
+GUI* get_InterfaceGui(this VerbCoin*)
+{
+  return interface;
+}
+
+void set_InventoryGui(this VerbCoin*, GUI* inventory_gui)
 {
   interface_inv = inventory_gui;
 }
 
-static function VerbCoin::RegisterActionLabel(Label* label)
+GUI* get_InventoryGui(this VerbCoin*)
+{
+  return interface_inv;
+}
+
+void set_ActionLabel(this VerbCoin*, Label* label)
 {
   action_label = label;
   action_label.Text = "";
+}
+
+Label* get_ActionLabel(this VerbCoin*)
+{
+  return action_label;
 }
 
 static function VerbCoin::Enable()
@@ -293,9 +333,14 @@ static function VerbCoin::IsOpen()
   return interface != null && interface.Visible;
 }
 
-static function VerbCoin::ButtonAutoDisable(bool autodisable)
+void set_ButtonAutoDisable(this VerbCoin*, bool autodisable)
 {
   button_auto_disable = autodisable;
+}
+
+bool get_ButtonAutoDisable(this VerbCoin*)
+{
+  return button_auto_disable;
 }
 
 function on_mouse_click(MouseButton button)

--- a/Verb Coin/VerbCoin.ash
+++ b/Verb Coin/VerbCoin.ash
@@ -13,21 +13,21 @@ enum VerbCoinPosition {
 };
 
 struct VerbCoin {
-	import static function SetRadius(int newradius);
-  import static function SetBackgroundTransparency(int transparency);
-  import static function SetBackgroundColor(int color);
-  import static function SetBorderColor(int color);
-  import static function SetBorderWidth(int width);
+  import static attribute int Radius;
+  import static attribute int BackgroundTransparency;
+  import static attribute int BackgroundColor;
+  import static attribute int BorderColor;
+  import static attribute int BorderWidth;
   import static function OnClick(GUIControl* control, MouseButton button);
   import static function RegisterButton(GUIControl* control, VerbCoinPosition position, CursorMode mode, String verbtext);
-  import static function RegisterInterfaceGui(GUI* interface_gui);
-  import static function RegisterInventoryGui(GUI* inventory_gui);
-  import static function RegisterActionLabel(Label* label);
+  import static attribute GUI* InterfaceGui;
+  import static attribute GUI* InventoryGui;
+  import static attribute Label* ActionLabel;
   import static function Enable();
   import static function Disable();
   import static function IsEnabled();
   import static function Open();
   import static function Close();
   import static function IsOpen();
-  import static function ButtonAutoDisable(bool autodisable);
+  import static attribute bool ButtonAutoDisable;
 };


### PR DESCRIPTION
Switches TwoClickHandler, VerbCoin, and KeyboardMovement scripts to use attributes (where possible).

For VerbCoin and KeyboardMovement this was just a change to the external interface. For TwoClickHandler the macro that defines the popup position is replaced by two attributes, default values will make the interface visible at 75% of the GUI height (so should be usable even where the GUI has been resized).