### PR TITLE
Sierra-style: handle inventory clicks in script

### DIFF
--- a/Sierra-style/Game.agf
+++ b/Sierra-style/Game.agf
@@ -43,7 +43,7 @@
       <GameTextEncoding>utf-8</GameTextEncoding>
       <Genre>Adventure</Genre>
       <GlobalSpeechAnimationDelay>5</GlobalSpeechAnimationDelay>
-      <HandleInvClicksInScript>False</HandleInvClicksInScript>
+      <HandleInvClicksInScript>True</HandleInvClicksInScript>
       <InventoryCursors>True</InventoryCursors>
       <InventoryHotspotMarkerCrosshairColor>5</InventoryHotspotMarkerCrosshairColor>
       <InventoryHotspotMarkerDotColor>6</InventoryHotspotMarkerDotColor>

--- a/Sierra-style/GlobalScript.asc
+++ b/Sierra-style/GlobalScript.asc
@@ -490,15 +490,9 @@ function on_key_press(eKeyCode keycode, int mod)
   }
 }
 
-// called when a mouse button is clicked
-function on_mouse_click(MouseButton button)
+function handle_room_click(MouseButton button)
 {
-  // called when a mouse button is clicked. button is either LEFT or RIGHT
-  if (IsGamePaused())
-  {
-    // game is paused, so do nothing (i.e. don't process mouse clicks)
-  }
-  else if (button == eMouseLeft)
+  if (button == eMouseLeft)
   {
     // left-click, so try using the current mouse cursor mode at this position
     Room.ProcessClick(mouse.x, mouse.y, mouse.Mode );
@@ -516,6 +510,54 @@ function on_mouse_click(MouseButton button)
   {
     // mouse wheel up will cycle the cursor mode backwards
     mouse.SelectPreviousMode();
+  }
+}
+
+function handle_inventory_click(MouseButton button)
+{
+  // InventoryItem.GetAtScreenXY could return null here
+  // so using game.inv_activated instead is a safer option
+  InventoryItem* item = inventory[game.inv_activated];
+  
+  if (button == eMouseLeftInv)
+  {
+    if (mouse.Mode == eModeInteract)
+    {
+      // interact mode selects an inventory item
+      player.ActiveInventory = item;
+    }
+    else if (mouse.Mode == eModeUseinv)
+    {
+      if (item.ID != player.ActiveInventory.ID)
+      {
+        // use one item on another
+        item.RunInteraction(eModeUseinv);
+      }
+    }
+    else
+    {
+      // otherwise run corresponding interaction (LookAt, etc)
+      item.RunInteraction(mouse.Mode);
+    }
+  }
+  else
+  {
+    // right click is always "Look At"
+    item.RunInteraction(eModeLookat);
+  }
+}
+
+// called when a mouse button is clicked
+function on_mouse_click(MouseButton button)
+{
+  if (button == eMouseLeftInv || button == eMouseRightInv || button == eMouseMiddleInv)
+  {
+    handle_inventory_click(button);
+  }
+  // game is paused, then don't process mouse clicks inside the room
+  else if (!IsGamePaused())
+  {
+    handle_room_click(button);
   }
 }
 


### PR DESCRIPTION
Resolves #25.

This reimplements default inventory handling in script. This is for consistency with other templates, and also to make it easier for users to adjust UI if they want to change something. Now they won't have to code things from scratch.