### PR TITLE
ci: add template build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: gets ags-toolbox
         run: |
-          curl -Lo atbx.exe https://github.com/ericoporto/agstoolbox/releases/download/0.5.0/atbx.exe
+          curl -Lo atbx.exe https://github.com/ericoporto/agstoolbox/releases/download/0.5.2/atbx.exe
           echo "${{github.workspace}}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install AGS
@@ -50,3 +50,33 @@ jobs:
             Sierra-style/Compiled/*/*
             Tumbleweed/Compiled/*/*
             Verb Coin/Compiled/*/*
+
+      - name: Create Templat Build dir
+        run: mkdir build
+
+      - name: Package BASS as Template
+        run: |
+          atbx export template ./BASS "BASS.agt" ./build
+
+      - name: Package Sierra-style as Template
+        run: |
+          atbx export template ./Sierra-style "Sierra-style.agt" ./build
+
+      - name: Package Tumbleweed as Template
+        run: |
+          atbx export template ./Tumbleweed "Tumbleweed.agt" ./build
+
+      - name: Package Verb Coin as Template
+        run: |
+          atbx export template "./Verb Coin" "Verb Coin.agt" ./build
+
+      - name: Package Empty Game as Template
+        run: |
+          atbx export template "./Empty Game" "Empty Game.agt" ./build
+
+      - name: Upload Artifacts of Templates
+        uses: actions/upload-artifact@v4
+        with:
+          name: templates
+          path: |
+            build/*.agt


### PR DESCRIPTION
after this change, no release change is added yet, but the CI will also package the template source files as template and make them available in a zip in the Actions tab, in a zip file named templates.

You can download them [here](https://github.com/adventuregamestudio/ags-template-source/actions/runs/10024105233/artifacts/1722439291).

My tool is currently packaging files using the [existing algorithm from the Editor reimplemented in python](https://github.com/ericoporto/agstoolbox/blob/main/src/agstoolbox/core/ags/ags_template.py#L42-L60), but I could also redo it in a different way.

fix #27 , we can still improve later and need to figure a scheme for releases but it should work. We can migrate to official tooling later.